### PR TITLE
Update 2015-11-26-meshviewer.md

### DIFF
--- a/_posts/2015-11-26-meshviewer.md
+++ b/_posts/2015-11-26-meshviewer.md
@@ -9,11 +9,3 @@ Der Meshviewer ist nun unter http://mesh.ffnord.net erreichbar.
 
 Derzeitig sind jedoch nur die Grundfunktionen aktiviert. In Zukunft ist ein Update auf v4 geplant und auch die Statistik 
 wird dann nach und nach eingerichtet.
-
-Bis die Statistiken ordentlich angezeigt werden, erhaltet Ihr so eure "Freifunk public IPv6" Adresse:
-
-Sucht euch die MAC Adresse eures Routers aus dem Meshviewer
-
-- geht auf http://tools.petrkadlec.com/lookup/ipv6eui64gen
-- Verwendet den Prefix: 2a03:2267:4e6f:7264::/64
-- fügt eure MAC mit : getrennt ein und klickt auf generate.


### PR DESCRIPTION
IPv6 Adressen teil entfernt, da der Meshviewer nun läuft und diese Daten dort abgelesen werden können.